### PR TITLE
ci: update release workflows to node version 18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 18
       - env:
           CI: true
         run: npm ci

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -9,9 +9,9 @@ jobs:
       -
         uses: actions/checkout@v1
       -
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 18
       -
         env:
           CI: true


### PR DESCRIPTION
Updates the release workflows from node 14 to 18. The workflow failed because timers/promises requires at least Node 15.

https://github.com/oleg-koval/semantic-release-npm-github-publish/actions/runs/6421100310/job/17434680590

```
internal/process/esm_loader.js:74
    internalBinding('errors').triggerUncaughtException(
                              ^

Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:timers/promises
    at new NodeError (internal/errors.js:322:7)
    at Loader.builtinStrategy (internal/modules/esm/translators.js:289:[11](https://github.com/oleg-koval/semantic-release-npm-github-publish/actions/runs/6421100310/job/17434680590#step:5:12))
    at new ModuleJob (internal/modules/esm/module_job.js:63:26)
    at Loader.getModuleJob (internal/modules/esm/loader.js:258:11)
    at async ModuleWrap.<anonymous> (internal/modules/esm/module_job.js:78:21)
    at async Promise.all (index 1)
    at async link (internal/modules/esm/module_job.js:83:9) {
  code: 'ERR_UNKNOWN_BUILTIN_MODULE'
}
```