### PR TITLE
Refresh README badges and align branch guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,10 @@ name: CI
 on:
   pull_request:
     branches:
-      - master
       - main
       - beta
   push:
     branches:
-      - master
       - main
       - beta
   workflow_dispatch:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master, main ]
+    branches: [ main ]
   schedule:
     - cron: '18 1 * * 0'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Publish
 on:
   push:
     branches:
-      - master
       - main
       - beta
 

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,20 @@
 # semantic-release-npm-github-publish
 
-<p>
+<p align="center">
   <a href="https://github.com/oleg-koval/semantic-release-npm-github-publish/actions/workflows/ci.yml" target="_blank">
     <img alt="CI" src="https://github.com/oleg-koval/semantic-release-npm-github-publish/actions/workflows/ci.yml/badge.svg?branch=main">
   </a>
   <a href="https://github.com/oleg-koval/semantic-release-npm-github-publish/actions/workflows/release.yml" target="_blank">
     <img alt="Publish" src="https://github.com/oleg-koval/semantic-release-npm-github-publish/actions/workflows/release.yml/badge.svg?branch=main">
   </a>
+  <a href="https://github.com/oleg-koval/semantic-release-npm-github-publish/actions/workflows/codeql-analysis.yml" target="_blank">
+    <img alt="CodeQL" src="https://github.com/oleg-koval/semantic-release-npm-github-publish/actions/workflows/codeql-analysis.yml/badge.svg?branch=main">
+  </a>
   <a href="https://www.npmjs.com/package/semantic-release-npm-github-publish" target="_blank">
     <img alt="npm" src="https://img.shields.io/npm/v/semantic-release-npm-github-publish.svg">
+  </a>
+  <a href="https://www.npmjs.com/package/semantic-release-npm-github-publish" target="_blank">
+    <img alt="npm downloads" src="https://img.shields.io/npm/dm/semantic-release-npm-github-publish.svg">
   </a>
   <a href="https://github.com/oleg-koval/semantic-release-npm-github-publish/blob/main/LICENSE" target="_blank">
     <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg" />
@@ -116,9 +122,8 @@ Use repo-local plugin composition instead when your team wants different plugins
 ## Repository Maintenance Notes
 
 - Consumer-facing examples now use `main`.
-- Repository automation currently supports both `master` and `main` so maintenance is not blocked before the branch rename.
-- Repository automation also supports `beta` for prerelease validation and publishing.
-- Renaming this repository's default branch to `main` is still recommended to align hosted defaults, badges, and examples.
+- Repository automation publishes stable releases from `main` and prereleases from `beta`.
+- The repository default branch is `main`, and all badges and examples now follow that.
 - The old README wording that inverted `fix` and `feat` was documentation drift. The actual release behavior has been corrected and is now covered by tests.
 
 ## Contributing

--- a/release.repo.config.js
+++ b/release.repo.config.js
@@ -3,7 +3,6 @@ const sharedConfig = require('./release.config');
 module.exports = {
 	...sharedConfig,
 	branches: [
-		{name: 'master', channel: 'latest'},
 		{name: 'main', channel: 'latest'},
 		{name: 'beta', prerelease: 'beta'},
 	],

--- a/test/release-config.test.js
+++ b/test/release-config.test.js
@@ -47,7 +47,6 @@ test('exports the documented plugin chain', () => {
 test('keeps beta prereleases as a repo-only branch policy', () => {
 	assert.equal(releaseConfig.branches, undefined);
 	assert.deepEqual(repoReleaseConfig.branches, [
-		{name: 'master', channel: 'latest'},
 		{name: 'main', channel: 'latest'},
 		{name: 'beta', prerelease: 'beta'},
 	]);


### PR DESCRIPTION
## Summary
Refresh the README badge block and remove stale master-branch guidance now that the repository has fully moved to main.

## Problem
The README still described the master-to-main transition and the repo-only release config/workflows still referenced master even though the default branch is main and the remote master branch is gone.

## Solution
Center the badge block, add a few high-signal badges, update the maintenance notes, and align the repo-only release policy and workflows to main plus beta.

## Changes
- center README badges and add CodeQL and npm downloads badges
- update README maintenance notes to reflect main as the live default branch
- remove master from repo-only release branches and workflow triggers
- update the branch-policy test accordingly

## Out of scope
- None

## Related issues
- None

## Validation
- npm test
- npm run docs:index:check

## Screenshots / Demo
- N/A

## Risk and impact
- Low; documentation and branch trigger cleanup only

## Breaking changes
- None

## Documentation
- README updated

## Reviewer notes
- This assumes the repository will continue using main for stable releases and beta for prereleases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD and release automation workflows to operate exclusively on `main` and `beta` branches, removing legacy branch support.
  * Updated release configuration to use only `main` and `beta` branches.

* **Documentation**
  * Clarified that stable releases publish from the `main` branch and prerelease versions from the `beta` branch.

* **Tests**
  * Updated release configuration tests to reflect the new branch strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->