### PR TITLE
Add Dependabot lockfile fixer workflow

### DIFF
--- a/.github/workflows/dependabot-lockfile-fixer.yml
+++ b/.github/workflows/dependabot-lockfile-fixer.yml
@@ -1,0 +1,45 @@
+name: Dependabot Lockfile Fixer
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-lockfile-fixer-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  fix-lockfiles:
+    if: >
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Fix lockfiles
+        uses: oleg-koval/dependabot-lockfile-fixer@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          package_manager: npm
+          working_directory: .

--- a/readme.md
+++ b/readme.md
@@ -116,9 +116,8 @@ Use repo-local plugin composition instead when your team wants different plugins
 ## Repository Maintenance Notes
 
 - Consumer-facing examples now use `main`.
-- Repository automation currently supports both `master` and `main` so maintenance is not blocked before the branch rename.
-- Repository automation also supports `beta` for prerelease validation and publishing.
-- Renaming this repository's default branch to `main` is still recommended to align hosted defaults, badges, and examples.
+- Repository automation publishes stable releases from `main` and prereleases from `beta`.
+- Dependabot PRs can auto-refresh `package-lock.json` through the dedicated lockfile-fixer workflow.
 - The old README wording that inverted `fix` and `feat` was documentation drift. The actual release behavior has been corrected and is now covered by tests.
 
 ## Contributing


### PR DESCRIPTION
## Summary
Add a dedicated workflow to auto-repair stale `package-lock.json` files on same-repo Dependabot PRs.

## Problem
This repository releases from CI and commits `package-lock.json`, so Dependabot PRs can drift behind `main` and fail with lockfile-only conflicts.

## Solution
Run `oleg-koval/dependabot-lockfile-fixer` on Dependabot pull requests with a narrow `pull_request_target` workflow and same-repo guard.

## Changes
- add `.github/workflows/dependabot-lockfile-fixer.yml`
- guard execution to `dependabot[bot]` and same-repo PR branches
- use Node 24 and `package_manager: npm`
- update the README maintenance note to mention automatic lockfile refresh
- remove stale README wording about the completed `master` to `main` migration

## Out of scope
- fixing dependency incompatibilities
- changing normal CI or release behavior
- handling non-lockfile merge conflicts

## Related issues
None

## Validation
- `npm run docs:index:check`

## Screenshots / Demo
N/A

## Risk and impact
Low. The workflow only runs for same-repo Dependabot PRs and only writes back to that PR branch.

## Breaking changes
None

## Documentation
Updated `readme.md` maintenance notes.

## Reviewer notes
This is intentionally isolated from the regular CI and release workflows so the fix path stays limited to Dependabot lockfile drift.
