### PR TITLE
Dependabot follow-up automation fixes

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,41 @@
+name: Dependabot Auto Merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enable-auto-merge:
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for safe npm updates
+        if: >
+          steps.metadata.outputs.package-ecosystem == 'npm_and_yarn' &&
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --merge "$PR_URL"

--- a/.github/workflows/dependabot-lockfile-fixer.yml
+++ b/.github/workflows/dependabot-lockfile-fixer.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   fix-lockfiles:
     if: >
-      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 

--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,7 @@ Use repo-local plugin composition instead when your team wants different plugins
 - Repository automation publishes stable releases from `main` and prereleases from `beta`.
 - The repository default branch is `main`, and all badges and examples now follow that.
 - Dependabot PRs can auto-refresh `package-lock.json` through the dedicated lockfile-fixer workflow.
+- Dependabot npm patch updates can enable GitHub auto-merge after required checks pass.
 - The old README wording that inverted `fix` and `feat` was documentation drift. The actual release behavior has been corrected and is now covered by tests.
 
 ## Contributing

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,11 @@ For this repository itself, stable releases come from `main` and prereleases com
 
 ## Usage
 
+<p>
+  <strong style="color:#b91c1c;">Migration notice:</strong>
+  this preset does not hardcode consumer release branches. `main` is the documented default, but if your repository still releases from `master` or another branch, set `branches` explicitly in your repo-local semantic-release config.
+</p>
+
 Example `.releaserc.yaml`:
 
 ```yaml
@@ -107,6 +112,17 @@ debug: false
 ```
 
 If your repository releases from a different branch, set `branches` explicitly in your repo-local config.
+
+Example migration from `master`:
+
+```yaml
+branches:
+  - master
+extends: "semantic-release-npm-github-publish"
+ci: false
+dryRun: false
+debug: false
+```
 
 ## When To Use This Preset
 
@@ -124,6 +140,7 @@ Use repo-local plugin composition instead when your team wants different plugins
 - Consumer-facing examples now use `main`.
 - Repository automation publishes stable releases from `main` and prereleases from `beta`.
 - The repository default branch is `main`, and all badges and examples now follow that.
+- The shared preset does not hardcode release branches for consumers; set `branches` in your repo-local config when you do not release from `main`.
 - Dependabot PRs can auto-refresh `package-lock.json` through the dedicated lockfile-fixer workflow.
 - Dependabot npm patch updates can enable GitHub auto-merge after required checks pass.
 - The old README wording that inverted `fix` and `feat` was documentation drift. The actual release behavior has been corrected and is now covered by tests.


### PR DESCRIPTION
## Summary
Land the Dependabot follow-up fixes that were added after PR #59 had already merged.

## Problem
PR #59 only merged the initial lockfile-fixer workflow. The later fixes for reopened Dependabot PRs, safe auto-merge, and the consumer branch-migration docs were still only on the feature branch and never reached `main`.

## Solution
Cherry-pick the missing follow-up commits onto a fresh branch from current `main` and open a new PR.

## Changes
- run the lockfile-fixer for reopened existing Dependabot PRs by checking the PR author instead of the triggering actor
- add a dedicated Dependabot auto-merge workflow for safe npm patch updates
- clarify in the README that the shared preset stays branch-agnostic for consumers and show a `master` migration override
- remove stale repo-owned `master` references from repo automation and tests

## Out of scope
- changing the shared preset to force branch names for consumers
- auto-merging minor or major dependency updates
- non-Dependabot PR automation

## Related issues
- #59
- #49

## Validation
- `npm test`
- `npm run docs:index:check`

## Screenshots / Demo
N/A

## Risk and impact
Low to medium. The new auto-merge path is intentionally limited to same-repo Dependabot npm patch updates and still depends on required checks passing.

## Breaking changes
None

## Documentation
Updated `readme.md` with migration guidance and explicit consumer branch configuration.

## Reviewer notes
This PR exists because the original PR #59 was merged before these follow-up commits were added to its branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated Dependabot npm patch updates now merge automatically following completion of required checks, reducing manual maintenance overhead

* **Documentation**
  * Added migration guide with branch configuration instructions for semantic-release preset implementations
  * Enhanced Dependabot documentation clarifying auto-merge support and setup requirements for npm patch updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->