### PR TITLE
feat: add Sell With boost badge to gh page footer

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -171,6 +171,9 @@ debug: false</code></pre>
         <span>MIT License</span>
         <span>Donations: off</span>
         <a href="https://github.com/oleg-koval">Oleg Koval</a>
+        <a href="https://sellwithboost.com" target="_blank" rel="noopener noreferrer">
+          <img src="https://sellwithboost.com/badge/listing.svg" alt="Listed on Sell With boost" style="height: 40px; width: auto;" />
+        </a>
       </footer>
     </main>
   </body>


### PR DESCRIPTION
Adds Sell With boost listing badge to the footer of the GitHub pages site.